### PR TITLE
Unnecessary startup exception

### DIFF
--- a/src/main/java/vg/civcraft/mc/civduties/database/Database.java
+++ b/src/main/java/vg/civcraft/mc/civduties/database/Database.java
@@ -52,7 +52,7 @@ public class Database {
         try {
             Class.forName("com.mysql.jdbc.Driver").newInstance();
         } catch (Exception ex) {
-            throw new DataSourceException("Failed to initialize JDBC driver.");
+            //throw new DataSourceException("Failed to initialize JDBC driver.");
         }
         try {
             connection = DriverManager.getConnection(jdbc);


### PR DESCRIPTION
This exception handling was introduced by roruke. It does not actually need to be thrown when starting a db connection, and causes an exception to be thrown on startup.